### PR TITLE
Backport of "[36] Override the ThreadContextMap in the provider."

### DIFF
--- a/src/main/java/org/jboss/logmanager/log4j/ThreadContextMDCMap.java
+++ b/src/main/java/org/jboss/logmanager/log4j/ThreadContextMDCMap.java
@@ -53,12 +53,11 @@ public class ThreadContextMDCMap implements ThreadContextMap {
     @Override
     public Map<String, String> getImmutableMapOrNull() {
         final Map<String, String> copy = MDC.copy();
-        return copy.isEmpty() ? null : copy;
+        return copy.isEmpty() ? null : Map.copyOf(copy);
     }
 
     @Override
     public boolean isEmpty() {
-        // Performance here is not great, but we need to use it as MDC.isEmpty() is not available in the log manager
         return MDC.copy().isEmpty();
     }
 

--- a/src/test/java/org/jboss/logmanager/log4j/ThreadContextMapTestCase.java
+++ b/src/test/java/org/jboss/logmanager/log4j/ThreadContextMapTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -50,8 +51,8 @@ public class ThreadContextMapTestCase extends AbstractTestCase {
         Assertions.assertEquals("test clear value", MDC.get(key));
 
         ThreadContext.clearMap();
-        Assertions.assertTrue(ThreadContext.isEmpty());
-        Assertions.assertTrue(MDC.copy().isEmpty());
+        Assert.assertTrue(ThreadContext.isEmpty());
+        Assert.assertTrue(MDC.copy().isEmpty());
     }
 
     @Test
@@ -63,8 +64,8 @@ public class ThreadContextMapTestCase extends AbstractTestCase {
         Assertions.assertEquals("test clear value", MDC.get(key));
 
         MDC.clear();
-        Assertions.assertTrue(ThreadContext.isEmpty());
-        Assertions.assertTrue(MDC.copy().isEmpty());
+        Assert.assertTrue(ThreadContext.isEmpty());
+        Assert.assertTrue(MDC.copy().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
backport fix for log4j ThreadContextMap for https://issues.redhat.com/browse/JBEAP-25900